### PR TITLE
Config bundler locally for path, without and gemfile options

### DIFF
--- a/lib/capistrano/tasks/bundler.cap
+++ b/lib/capistrano/tasks/bundler.cap
@@ -25,13 +25,18 @@ namespace :bundler do
     on fetch(:bundle_servers) do
       within release_path do
         with fetch(:bundle_env_variables, {}) do
-          options = []
-          options << "--gemfile #{fetch(:bundle_gemfile)}" if fetch(:bundle_gemfile)
-          options << "--path #{fetch(:bundle_path)}" if fetch(:bundle_path)
-          unless test(:bundle, :check, *options)
+          bundle_path = fetch(:bundle_path)
+          bundle_without = fetch(:bundle_without)
+          bundle_gemfile = fetch(:bundle_gemfile)
+
+          execute :bundle, :config, "--local path #{bundle_path}" if bundle_path
+          execute :bundle, :config, "--local without #{bundle_without.split(' ').join(':')}" if bundle_without
+          execute :bundle, :config, "--local gemfile #{bundle_gemfile}" if bundle_gemfile
+
+          unless test(:bundle, :check)
+            options = []
             options << "--binstubs #{fetch(:bundle_binstubs)}" if fetch(:bundle_binstubs)
             options << "--jobs #{fetch(:bundle_jobs)}" if fetch(:bundle_jobs)
-            options << "--without #{fetch(:bundle_without)}" if fetch(:bundle_without)
             options << "#{fetch(:bundle_flags)}" if fetch(:bundle_flags)
             execute :bundle, :install, *options
           end


### PR DESCRIPTION
### The problem
`bundle check` always failed for me, cause it worked with different options than `bundle install`
- it worked with different `path`
- and different `without`

After some investigation I succeed to pass relevant options to `bundle check`, so it passed successfully.
But after than `bundle exec` failed. Because it **relied on options that was set during `bundle install`**!

### The solution
I suggest to config relevant options beforehand, so `bundle check`, `bundle install`, `bundle exec` all work in the same context.
